### PR TITLE
Update angular-confirm.js

### DIFF
--- a/angular-confirm.js
+++ b/angular-confirm.js
@@ -17,13 +17,17 @@ angular.module('angular-confirm', ['ui.bootstrap'])
   };
 }])
 .value('$confirmModalDefaults', {
-  template: '<div class="modal-header"><h3 class="modal-title">Confirm</h3></div><div class="modal-body">{{data.text}}</div><div class="modal-footer"><button class="btn btn-primary" ng-click="ok()">OK</button><button class="btn btn-warning" ng-click="cancel()">Cancel</button></div>',
-  controller: 'ConfirmModalController'
+  template: '<div class="modal-header"><h3 class="modal-title">{{data.title}}</h3></div><div class="modal-body">{{data.text}}</div><div class="modal-footer"><button class="btn btn-primary" ng-click="ok()">OK</button><button class="btn btn-warning" ng-click="cancel()">Cancel</button></div>',
+  controller: 'ConfirmModalController',
+  defaultTitle: 'Confirm'
 })
 .factory('$confirm', ['$modal', '$confirmModalDefaults', function($modal, $confirmModalDefaults) {
   return function(data, settings) {
     settings = angular.extend($confirmModalDefaults, (settings || {}));
     data = data || {};
+    
+    data.title = data.title || settings.defaultTitle;
+    delete settings.defaultTitle;
     
     if ('templateUrl' in settings && 'template' in settings) {
       delete settings.template;


### PR DESCRIPTION
Make title configurable in the default settings with the property `defaultTitle` or configurable by passing in the `title` key in the data passed into the $confirm factory. The title passed by data overrides the default.
