### PR TITLE
Added a showCancel option to explicitly remove cancel button if wished

### DIFF
--- a/angular-confirm.js
+++ b/angular-confirm.js
@@ -22,7 +22,7 @@ angular.module('angular-confirm', ['ui.bootstrap'])
     '<div class="modal-body">{{data.text}}</div>' +
     '<div class="modal-footer">' +
     '<button class="btn btn-primary" ng-click="ok()">{{data.ok}}</button>' +
-    '<button class="btn btn-default" ng-click="cancel()">{{data.cancel}}</button>' +
+    '<button class="btn btn-default" ng-click="cancel()" ng-hide="data.showCancel === false">{{data.cancel}}</button>' +
     '</div>',
     controller: 'ConfirmModalController',
     defaultLabels: {
@@ -33,6 +33,7 @@ angular.module('angular-confirm', ['ui.bootstrap'])
   })
   .factory('$confirm', ['$modal', '$confirmModalDefaults', function ($modal, $confirmModalDefaults) {
     return function (data, settings) {
+
       settings = angular.extend($confirmModalDefaults, (settings || {}));
 
       data = angular.extend({}, settings.defaultLabels, data || {});
@@ -61,7 +62,8 @@ angular.module('angular-confirm', ['ui.bootstrap'])
         confirmSettings: "=",
         confirmTitle: '@',
         confirmOk: '@',
-        confirmCancel: '@'
+        confirmCancel: '@',
+        confirmShowCancel: "=",
       },
       link: function (scope, element, attrs) {
 
@@ -82,6 +84,12 @@ angular.module('angular-confirm', ['ui.bootstrap'])
             if (scope.confirmCancel) {
               data.cancel = scope.confirmCancel;
             }
+            if (!angular.isUndefined(scope.confirmShowCancel) && scope.confirmShowCancel === false) {
+              data.showCancel = false;
+            } else {
+              data.showCancel = true;
+            }
+
             $confirm(data, scope.confirmSettings || {}).then(scope.ngClick);
           } else {
 

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "homepage": "https://github.com/Schlogen/angular-confirm",
   "devDependencies": {
     "angular": "1.4.2",
-    "angular-bootstrap": "0.12.0",
     "angular-mocks": "^1.4.2",
+    "angular-ui-bootstrap": "0.12.1",
     "gulp": "3.9.0",
     "jasmine-core": "^2.3.4",
     "karma": "0.12.37",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       '../node_modules/angular/angular.js',
-      '../node_modules/angular-bootstrap/dist/ui-bootstrap-tpls.js',
+      '../node_modules/angular-ui-bootstrap/ui-bootstrap-tpls.js',
       '../node_modules/angular-mocks/angular-mocks.js',
       '../angular-confirm.js',
       'unit/**/*Spec.js'

--- a/test/unit/confirmSpec.js
+++ b/test/unit/confirmSpec.js
@@ -88,6 +88,12 @@ describe('angular-confirm', function() {
             expect(settings.template).not.toBeDefined();
         });
 
+        it("should not display cancel button if showCancel evaluates to false", function() {
+            var settings = $confirm({showCancel: false});
+            var data = settings.resolve.data();
+            expect(data.showCancel).toEqual(false);
+        });
+
     });
 
     describe('confirm directive', function() {
@@ -214,7 +220,7 @@ describe('angular-confirm', function() {
 
             it("should pass the settings to $confirm", function() {
                 element.triggerHandler('click');
-                expect($confirm).toHaveBeenCalledWith({text: "Are you sure?"}, $scope.settings)
+                expect($confirm).toHaveBeenCalledWith({text: "Are you sure?", showCancel: true}, $scope.settings)
             });
         });
 
@@ -227,7 +233,34 @@ describe('angular-confirm', function() {
 
             it("should pass the settings to $confirm", function() {
                 element.triggerHandler('click');
-                expect($confirm).toHaveBeenCalledWith({text: "Are you sure?"}, {name: "Joe"})
+                expect($confirm).toHaveBeenCalledWith({text: "Are you sure?", showCancel: true}, {name: "Joe"})
+            });
+        });
+
+        describe('with confirmShowCancel evaluating to true present', function() {
+            beforeEach(angular.mock.inject(function($compile) {
+                element = angular.element('<button type="button" ng-click="click()" confirm="Are you sure?" confirm-settings="{name: \'Joe\'}" confirm-show-cancel="true">Delete</button>');
+                $compile(element)($scope);
+                $scope.$digest();
+            }));
+
+            it("should pass the showCancel data to $confirm", function() {
+                element.triggerHandler('click');
+                expect($confirm).toHaveBeenCalledWith({text: "Are you sure?", showCancel: true}, {name: "Joe"})
+            });
+        });
+
+
+        describe('with confirmShowCancel evaluating to false present', function() {
+            beforeEach(angular.mock.inject(function($compile) {
+                element = angular.element('<button type="button" ng-click="click()" confirm="Are you sure?" confirm-settings="{name: \'Joe\'}" confirm-show-cancel="false">Delete</button>');
+                $compile(element)($scope);
+                $scope.$digest();
+            }));
+
+            it("should pass the settings to $confirm", function() {
+                element.triggerHandler('click');
+                expect($confirm).toHaveBeenCalledWith({text: "Are you sure?", showCancel: false}, {name: "Joe"})
             });
         });
 


### PR DESCRIPTION
I needed some confirm dialogs for a customers project, where the customer only wanted to show up a "OK" button as the information was just "read this and then go ahead", so that showing up a cancel button would only confuse users.

So this is what I changed. The changes should be completely compatible with the current implementation, as the button will only be hidden, if `showCancel` is explicitly set and evaluates to `false`.

Hope this will help some others too.
