### PR TITLE
Reduce the scope of the Angular UI Bootstrap dependency to only the $modal service

### DIFF
--- a/angular-confirm.js
+++ b/angular-confirm.js
@@ -4,7 +4,7 @@
  * Version: 1.1.1 - 2015-08-10
  * License: Apache
  */
-angular.module('angular-confirm', ['ui.bootstrap'])
+angular.module('angular-confirm', [ 'ui.bootstrap.modal'])
   .controller('ConfirmModalController', ['$scope', '$modalInstance', 'data', function ($scope, $modalInstance, data) {
     $scope.data = angular.copy(data);
 


### PR DESCRIPTION
Only require the modal module to use with this component to prevent conflicts with AngularStrap
