### PR TITLE
apply SPDX License Expression Syntax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,5 @@
     "James Kleeh"
   ],
   "description": "Confirmation modal dialog for AngularJS",
-  "license": "Apache"
+  "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "$modal"
   ],
   "author": "James Kleeh",
-  "license": "Apache",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/Schlogen/angular-confirm/issues"
   },


### PR DESCRIPTION
Hi Schlogen, 

Let's apply the [SPDX](https://docs.npmjs.com/files/package.json#license) to the license field of `package.json` and  `bower.json`.

I would like to use `angular-confirm` from [webjars.org](http://www.webjars.org/).
but, when I "Add a New NPM WebJar", got the following results.

> Failed! No valid licenses found. Detected licenses: Apache The acceptable licenses on BinTray are at: https://bintray.com/docs/api/#_footnote_1 License detection first uses the package metadata (e.g. package.json or bower.json) and falls back to looking for a LICENSE, LICENSE.txt, or LICENSE.md file in the master branch of the GitHub repo. Since these methods failed to detect a valid license you will need to work with the upstream project to add discoverable license metadata to a release or to the GitHub repo. 

Please merge this branch with the master. 

Thanks
