### PR TITLE
Update angular-confirm.js to support custom response messages

### DIFF
--- a/angular-confirm.js
+++ b/angular-confirm.js
@@ -29,7 +29,9 @@ angular.module('angular-confirm', ['ui.bootstrap.modal'])
     };
 
     $scope.cancel = function (dismissMessage) {
-      if (angular.isUndefined(dismissMessage)) dismissMessage = 'cancel';
+      if (angular.isUndefined(dismissMessage)) {
+        dismissMessage = 'cancel';
+      }
       $uibModalInstance.dismiss(dismissMessage);
     };
 

--- a/angular-confirm.js
+++ b/angular-confirm.js
@@ -29,7 +29,7 @@ angular.module('angular-confirm', ['ui.bootstrap.modal'])
     };
 
     $scope.cancel = function (dismissMessage) {
-      if (typeof dismissMessage === 'undefined') dismissMessage = 'cancel';
+      if (angular.isUndefined(dismissMessage)) dismissMessage = 'cancel';
       $uibModalInstance.dismiss(dismissMessage);
     };
 

--- a/angular-confirm.js
+++ b/angular-confirm.js
@@ -24,12 +24,13 @@ angular.module('angular-confirm', ['ui.bootstrap.modal'])
   .controller('ConfirmModalController', function ($scope, $uibModalInstance, data) {
     $scope.data = angular.copy(data);
 
-    $scope.ok = function () {
-      $uibModalInstance.close();
+    $scope.ok = function (closeMessage) {
+      $uibModalInstance.close(closeMessage);
     };
 
-    $scope.cancel = function () {
-      $uibModalInstance.dismiss('cancel');
+    $scope.cancel = function (dismissMessage) {
+      if (typeof dismissMessage === 'undefined') dismissMessage = 'cancel';
+      $uibModalInstance.dismiss(dismissMessage);
     };
 
   })


### PR DESCRIPTION
Supporting customized response messages allows custom templates to offer more than the standard 'ok' and 'cancel' buttons.
