### PR TITLE
Add ignore key to Bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,15 @@
   "name": "angular-confirm-modal",
   "main": "angular-confirm.min.js",
   "version": "1.2.3",
+  "ignore": [
+    "test",
+    "package.json",
+    "gulpfile.js",
+    "LICENSE",
+    ".gitignore",
+    "*.md",
+    ".travis.yml"
+  ],
   "homepage": "https://github.com/Schlogen/angular-confirm",
   "authors": [
     "James Kleeh"


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#ignore

To get rid of this warning:

```
bower invalid-meta  angular-confirm-modal is missing "ignore" entry in bower.json
```

And to make bower package more compact.
