### PR TITLE
Don't point to minified version from Bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-confirm-modal",
-  "main": "angular-confirm.min.js",
+  "main": "angular-confirm.js",
   "version": "1.2.3",
   "ignore": [
     "test",


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#main

> Do not include minified files.

http://stackoverflow.com/questions/24852850/why-is-bower-recommending-to-ignore-minified-source-file

;-)

People using `main` key are likely using also their own build processes / minify JS on their own.
