### PR TITLE
Fix broken tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "angular": "1.4.7",
     "angular-ui-bootstrap": "0.14.3",
-    "angular-mocks": "^1.4.7",
+    "angular-mocks": "1.4.7",
     "gulp": "3.9.0",
     "gulp-bump": "^1.0.0",
     "gulp-git": "^1.6.0",


### PR DESCRIPTION
Angular-mocks must be the same version as angular.
