### PR TITLE
Fix bug when using nested ng-click

### DIFF
--- a/angular-confirm.js
+++ b/angular-confirm.js
@@ -94,7 +94,7 @@ angular.module('angular-confirm', ['ui.bootstrap.modal'])
         }
 
         element.unbind("click").bind("click", function ($event) {
-
+          $event.stopPropagation();
           $event.preventDefault();
 
           $timeout(function() {


### PR DESCRIPTION
I just add $event.stopPropagation(); when binding click event. That what the problem I found when parent element has click event.
