### PR TITLE
Remove broken demo link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@ angular-confirm
 ===============
 [![Build Status](https://travis-ci.org/jameskleeh/angular-confirm.svg?branch=master)](https://travis-ci.org/jameskleeh/angular-confirm)
 
-Confirm modal dialog for Angular 2!
+Confirm modal dialog for Angular v2+!
 
 The AngularJS version is maintained in the [1.2.x branch](https://github.com/jameskleeh/angular-confirm/tree/1.2.x)
-
-See [demo](http://jameskleeh.github.io/angular-confirm/angular2)
 
 ## Install
 This module requires the Ng-Bootstrap [NgbModal](https://ng-bootstrap.github.io/#/components/modal). The default template uses styles from [Bootstrap](http://v4-alpha.getbootstrap.com/) 4.x.


### PR DESCRIPTION
- Remove broken demo link (related to _Update demo page_ #77)
- Change "Angular 2" to "Angular v2+" (as this should work with v3, v4 etc. See [Angular versioning](https://angularjs.blogspot.lt/2016/10/versioning-and-releasing-angular.html) update)